### PR TITLE
Prevent integration while counter is active

### DIFF
--- a/TimeIntegrationApp.sln
+++ b/TimeIntegrationApp.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.28307.1321
+# Visual Studio Version 17
+VisualStudioVersion = 17.9.34622.214
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TimeIntegrationApp", "TimeIntegrationApp\TimeIntegrationApp.csproj", "{8B99AD93-5FF0-4AD9-A139-1A555FDB245F}"
 EndProject

--- a/TimeIntegrationApp/Clockify/ClockifyTimeEntry.cs
+++ b/TimeIntegrationApp/Clockify/ClockifyTimeEntry.cs
@@ -22,8 +22,26 @@ namespace TimeIntegrationApp.Clockify
     }
     class ClockifyInterval
     {
-        public DateTime Start { get; set; }
-        public DateTime End { get; set; }
+        private DateTime? _start;
+        private DateTime? _end;
+
+        public DateTime? Start
+        {
+            get => _start;
+            set
+            {
+                _start = value ?? throw new EmptyDateException(nameof(Start));
+            }
+        }
+
+        public DateTime? End 
+        { 
+            get => _end;
+            set
+            {
+                _end = value ?? throw new EmptyDateException(nameof(End), "Stop the Clockify counter and try again.");
+            }
+        }
         public String Duration { get; set; }
     }
 }

--- a/TimeIntegrationApp/Exceptions/EmptyDateException.cs
+++ b/TimeIntegrationApp/Exceptions/EmptyDateException.cs
@@ -1,0 +1,15 @@
+﻿using Newtonsoft.Json.Converters;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace TimeIntegrationApp
+{
+    internal class EmptyDateException : ArgumentNullException
+    {
+        public EmptyDateException(string paramName, string details = "") : base(paramName, $"{paramName} date cannot be empty.{(string.IsNullOrEmpty(details) ? "" : $"  {details}")}") { }
+    }   
+}

--- a/TimeIntegrationApp/Services/ITaskReader.cs
+++ b/TimeIntegrationApp/Services/ITaskReader.cs
@@ -12,6 +12,6 @@ namespace TimeIntegrationApp
         List<WorkItem> ReadWorkItems(Project p);
         List<Project> ReadProjects();
         Project ReadProject(string id);
-        List<TimeIntegrationApp.Models.TimeEntry> ReadTimeEntries(DateTime from, DateTime to);
+        (bool, List<TimeIntegrationApp.Models.TimeEntry>) ReadTimeEntries(DateTime from, DateTime to, log4net.ILog log);
     }
 }

--- a/TimeIntegrationApp/Services/Integrator.cs
+++ b/TimeIntegrationApp/Services/Integrator.cs
@@ -74,12 +74,17 @@ namespace TimeIntegrationApp.Services
             for (DateTime date = from; date <= to; date = date.AddDays(1.0))
             {
                 log.Info($"{date:yyyy-MM-dd}");
-                var entries = TimeReader.ReadTimeEntries(date,date);
-                log.Info($"Read {entries.Count} entries");
-                WriteStatus s = TimeWriter.WriteTimeEntries(entries);
-                log.Info($"Created {s.created} entries");
+                (bool successfulReading, var entries) = TimeReader.ReadTimeEntries(date,date, log);
+                if (successfulReading)
+                {
+                    log.Info($"Read {entries.Count} entries");
+                    WriteStatus s = TimeWriter.WriteTimeEntries(entries);
+                    log.Info($"Created {s.created} entries");
+                } else
+                {
+                    break;
+                }
             }
-
 
         }
 

--- a/TimeIntegrationApp/TimeIntegrationApp.csproj
+++ b/TimeIntegrationApp/TimeIntegrationApp.csproj
@@ -119,6 +119,7 @@
     <Compile Include="Clockify\ClockifyTimeEntry.cs" />
     <Compile Include="Clockify\ClockifyWriter.cs" />
     <Compile Include="Clockify\User.cs" />
+    <Compile Include="Exceptions\EmptyDateException.cs" />
     <Compile Include="Helpers\JsonSerializer.cs" />
     <Compile Include="Models\Project.cs" />
     <Compile Include="Models\TimeEntry.cs" />

--- a/TimeIntegrationApp/Upland/UplandReader.cs
+++ b/TimeIntegrationApp/Upland/UplandReader.cs
@@ -107,9 +107,9 @@ namespace TimeIntegrationApp.Upland
             };
             
         }
-        public List<TimeIntegrationApp.Models.TimeEntry> ReadTimeEntries(DateTime from, DateTime to)
+        public (bool, List<TimeIntegrationApp.Models.TimeEntry>) ReadTimeEntries(DateTime from, DateTime to, log4net.ILog log)
         {
-            return null;
+            return (false, null);
         }
 
     }


### PR DESCRIPTION
When trying to run integration between Clockify and Upland, Clockify **must not have** active counter running because it sets `end` time as `null` and prevents sucessfull integration with Upland. 

Up till now the app would crash with deserialization exception, but these changes will let user know what is going on and end process in a clean way.

### Some additional illustrations:

Active clockify counter:
![clockify-active-counter](https://github.com/dariuskava/TimeIntegrationApp/assets/47061836/5c02b263-f8bb-4704-98fe-8537446dfba9)

The runtime error of failed time parsing:
![endNullException](https://github.com/dariuskava/TimeIntegrationApp/assets/47061836/a9a8eeff-689f-4d3d-b4a6-1ea1ca3319df)

After these changes user will be notified like this and app will close:
![clockify-stop-message](https://github.com/dariuskava/TimeIntegrationApp/assets/47061836/d9514f62-447f-4451-88c2-f213be91ad67)
